### PR TITLE
Fixes ImportError on Python 3.

### DIFF
--- a/langid/__init__.py
+++ b/langid/__init__.py
@@ -1,1 +1,1 @@
-from langid import classify, rank, set_languages
+from .langid import classify, rank, set_languages


### PR DESCRIPTION
Without this relative import Python 3 will try to import 'classify', etc. from the langid module (instead of the langid.py file) because absolute imports are now a default.