### PR TITLE
langid.py: Fix for issue #29

### DIFF
--- a/langid/langid.py
+++ b/langid/langid.py
@@ -604,7 +604,7 @@ def main():
     else:
       # Redirected
       if options.line:
-        for line in sys.stdin.readlines():
+        for line in sys.stdin:
           print(_process(line))
       else:
         print(_process(sys.stdin.read()))


### PR DESCRIPTION
When classifying a line at a time, only read a line at a time, so as to
prevent Python from loading a large file into memory needlessly.

https://github.com/saffsd/langid.py/issues/29